### PR TITLE
Remove unnecessary exception

### DIFF
--- a/GDLibrary/GDLibrary/Managers/Game/TimerManager.cs
+++ b/GDLibrary/GDLibrary/Managers/Game/TimerManager.cs
@@ -196,7 +196,7 @@ namespace GDLibrary
                                         loseEventFired = true;
                                     }
                                     else
-                                        throw new NotImplementedException("Event doesn't exist for this timer");
+                                        System.Diagnostics.Debug.WriteLine("Event doesn't exist for this timer " + timer.ID);
                                 }
                                 else
                                     throw new Exception("Hour check has gone wrong");


### PR DESCRIPTION
Throwing an exception is excessive for what we need to do. 
Not all timers need to throw an event.