### PR TITLE
Fixed win screen bug

### DIFF
--- a/GDApp/GDApp/App/Main.cs
+++ b/GDApp/GDApp/App/Main.cs
@@ -1542,7 +1542,8 @@ namespace GDApp
         private void WinTriggered(EventData eventData)
         {
             EventDispatcher.Publish(new EventData(EventActionType.OnWin, EventCategoryType.MainMenu));
-            //EventDispatcher.Publish(new EventData(EventActionType.OnWin, EventCategoryType.mouseLock));
+            EventDispatcher.Publish(new EventData(EventActionType.OnPause, EventCategoryType.MainMenu));
+            EventDispatcher.Publish(new EventData(EventActionType.OnWin, EventCategoryType.mouseLock));
         }
 
         private void Reset(EventData eventData)


### PR DESCRIPTION
when the player completed the level the mouse got stuck in the middle of
the screen and the collisions in the level would still be drawn. Now the
game is set to be paused and the mouse is no longer stuck in the middle.